### PR TITLE
Use forwarded listener ip address

### DIFF
--- a/conf/icecast.xml.in
+++ b/conf/icecast.xml.in
@@ -204,6 +204,7 @@
         <logdir>@localstatedir@/log/@PACKAGE@</logdir>
         <webroot>@pkgdatadir@/web</webroot>
         <adminroot>@pkgdatadir@/admin</adminroot>
+        <x-forwarded-for></x-forwarded-for>
         <!-- <pidfile>@pkgdatadir@/icecast.pid</pidfile> -->
         <!-- <ssl-certificate>@pkgdatadir@/icecast.pem</ssl-certificate> -->
         <!-- <deny-ip>/path/to/file-with-IPs</deny-ip> -->

--- a/configure
+++ b/configure
@@ -3099,7 +3099,7 @@ fi
 
 # Define the identity of the package.
  PACKAGE='icecast'
- VERSION='2.4.0-kh15'
+ VERSION='2.4.0-kh15-cheeky'
 
 
 cat >>confdefs.h <<_ACEOF

--- a/src/connection.c
+++ b/src/connection.c
@@ -1390,7 +1390,12 @@ static int http_client_request (client_t *client)
                             return -1;
                     }
                     else
+                    {
+                        DEBUG1("No x-forwarded-for match for %s", str);
                         config_release_config();
+                    }
+                } else {
+                    DEBUG1("No x-forwarded-for header found in %s", (char *) client->parser);
                 }
 
                 if (useragents.filename)

--- a/src/connection.c
+++ b/src/connection.c
@@ -823,6 +823,7 @@ static struct xforward_entry *_find_xforward_addr (ice_config_t *config, char *i
             break;
         xforward = xforward->next;
     }
+    DEBUG2 ("Using %s for %s", xforward->ip, ip);
     return xforward;
 }
 

--- a/src/httpp/httpp.c
+++ b/src/httpp/httpp.c
@@ -80,7 +80,7 @@ static int split_headers(char *data, unsigned long len, char **line)
                 if (data[i + 1] == '\n' || data[i + 1] == '\r')
                     break;
                 line[lines] = &data[i + 1];
-                DEBUG1("Read header %s", line[lines]);
+                printf("Read header %s \n", line[lines]);
             }
         }
     }

--- a/src/httpp/httpp.c
+++ b/src/httpp/httpp.c
@@ -80,6 +80,7 @@ static int split_headers(char *data, unsigned long len, char **line)
                 if (data[i + 1] == '\n' || data[i + 1] == '\r')
                     break;
                 line[lines] = &data[i + 1];
+                DEBUG1("Read header %s", line[lines]);
             }
         }
     }
@@ -307,6 +308,7 @@ int httpp_parse(http_parser_t *parser, const char *http_data, unsigned long len)
     data[len] = 0;
 
     lines = split_headers(data, len, line);
+    DEBUG1("Found %d headers", lines);
 
     /* parse the first line special
     ** the format is:

--- a/src/httpp/httpp.c
+++ b/src/httpp/httpp.c
@@ -308,7 +308,7 @@ int httpp_parse(http_parser_t *parser, const char *http_data, unsigned long len)
     data[len] = 0;
 
     lines = split_headers(data, len, line);
-    DEBUG1("Found %d headers", lines);
+    printf("Found %d headers\n", lines);
 
     /* parse the first line special
     ** the format is:

--- a/src/httpp/httpp.c
+++ b/src/httpp/httpp.c
@@ -22,6 +22,9 @@
 #include <avl/avl.h>
 #include "httpp.h"
 #include "global.h"
+#include "logging.h"
+
+#define CATMODULE "httpp"
 
 #if defined(_WIN32) && !defined(HAVE_STRCASECMP)
 #define strcasecmp stricmp
@@ -80,7 +83,6 @@ static int split_headers(char *data, unsigned long len, char **line)
                 if (data[i + 1] == '\n' || data[i + 1] == '\r')
                     break;
                 line[lines] = &data[i + 1];
-                printf("Read header %s \n", line[lines]);
             }
         }
     }
@@ -124,6 +126,7 @@ static void parse_headers(http_parser_t *parser, char **line, int lines)
         
         if (name != NULL && value != NULL) {
             httpp_setvar(parser, _lowercase(name), value);
+            DEBUG2("Header %s: %s", _lowercase(name), value);
             name = NULL; 
             value = NULL;
         }
@@ -308,7 +311,6 @@ int httpp_parse(http_parser_t *parser, const char *http_data, unsigned long len)
     data[len] = 0;
 
     lines = split_headers(data, len, line);
-    printf("Found %d headers\n", lines);
 
     /* parse the first line special
     ** the format is:

--- a/src/httpp/httpp.h
+++ b/src/httpp/httpp.h
@@ -10,6 +10,7 @@
 #define __HTTPP_H
 
 #include <avl/avl.h>
+#include <logging.h>
 
 #define HTTPP_VAR_PROTOCOL "__protocol"
 #define HTTPP_VAR_VERSION "__version"

--- a/src/httpp/httpp.h
+++ b/src/httpp/httpp.h
@@ -10,7 +10,6 @@
 #define __HTTPP_H
 
 #include <avl/avl.h>
-#include <logging.h>
 
 #define HTTPP_VAR_PROTOCOL "__protocol"
 #define HTTPP_VAR_VERSION "__version"


### PR DESCRIPTION
Adds configuration for so it can have a value substituted by cheekychops/docker-icecast-kh.

But that appears not to be the problem...

The headers on the listener's connection request do not appear to be parsed. The only parsing of headers is on the Source connection (which comes from liquidsoap in our implementation).